### PR TITLE
Configurable Docker network for running Testcontainers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       POETRY_VIRTUALENVS_CREATE: false
+      TESTCONTAINER_DOCKER_NETWORK: tomodachi-testcontainers
     strategy:
       max-parallel: 4
       matrix:
@@ -49,6 +50,9 @@ jobs:
 
       - name: Run commit hooks
         run: SKIP=test poetry run hooks
+
+      - name: Create Docker network for running Testcontianers
+        run: docker network create $TESTCONTAINER_DOCKER_NETWORK
 
       - name: Run tests
         run: poetry run test-ci

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,7 @@ jobs:
         run: SKIP=test poetry run hooks
 
       - name: Create Docker network for running Testcontianers
-        run: docker network create $TESTCONTAINER_DOCKER_NETWORK
+        run: docker network ls | grep $TESTCONTAINER_DOCKER_NETWORK || docker network create $TESTCONTAINER_DOCKER_NETWORK
 
       - name: Run tests
         run: poetry run test-ci

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ It facilitates the use of Docker containers for functional, integration, and end
     - [Testing Tomodachi service with external dependencies](#testing-tomodachi-service-with-external-dependencies)
   - [Benefits and dangers of end-to-end tests](#benefits-and-dangers-of-end-to-end-tests)
     - [Building confidence of releasability](#building-confidence-of-releasability)
-    - [⚠️ Mind the Test Pyramid - not overdo end-to-end tests](#️-mind-the-test-pyramid---not-overdo-end-to-end-tests)
+    - [⚠️ Mind the Test Pyramid - don't overdo end-to-end tests](#️-mind-the-test-pyramid---dont-overdo-end-to-end-tests)
   - [Running Testcontainers in CI pipeline](#running-testcontainers-in-ci-pipeline)
   - [Supported Testcontainers](#supported-testcontainers)
     - [Tomodachi](#tomodachi)
     - [Moto](#moto)
     - [LocalStack](#localstack)
     - [SFTP](#sftp)
+  - [Configuration with environment variables](#configuration-with-environment-variables)
   - [Resources and acknowledgements](#resources-and-acknowledgements)
   - [Development](#development)
 
@@ -363,7 +364,7 @@ Testcontainers make it easy to spin up real dependencies in Docker containers, a
 when the tests are finished. They work in thw same way locally and in the CI pipeline, so you need to
 setup test suite only once._
 
-### ⚠️ Mind the Test Pyramid - not overdo end-to-end tests
+### ⚠️ Mind the Test Pyramid - don't overdo end-to-end tests
 
 Despite many benefits of end-to-end tests, they are the most expensive kind 💸 -
 they're slow, sometimes [flaky](https://martinfowler.com/articles/nonDeterminism.html),
@@ -478,6 +479,14 @@ DockerHub: <https://hub.docker.com/r/atmoz/sftp>
 - Available as an extra dependency `sftp` - install with
   `pip install tomodachi-testcontainers[sftp]` or `poetry install -E sftp`
 
+## Configuration with environment variables
+
+| Environment Variable                      | Description                                                                                                                   |
+| :---------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `TESTCONTAINER_DOCKER_NETWORK`            | Launch testcontainers in specified Docker network. Defaults to 'bridge'. Network must be created beforehand                   |
+| `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH` | Override path to Dockerfile for building Tomodachi service image. Defaults to '.'                                             |
+| `<CONTAINER-NAME>_TESTCONTAINER_IMAGE_ID` | Override any supported Testcontainer Image ID. Defaults to `None`, `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH` takes precedence |
+
 ## Resources and acknowledgements
 
 - [testcontainers.com](https://testcontainers.com/) - home of Testcontainers.
@@ -517,6 +526,8 @@ pre-commit install
 - Run tests
 
 ```bash
+docker network create tomodachi-testcontainers
+
 pytest
 poetry run test-ci
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It facilitates the use of Docker containers for functional, integration, and end
 
 - [tomodachi-testcontainers](#tomodachi-testcontainers)
   - [Installation](#installation)
-  - [Quickstart and Examples](#quickstart-and-examples)
+  - [Quickstart and examples](#quickstart-and-examples)
   - [Getting started](#getting-started)
     - [Testing standalone Tomodachi service](#testing-standalone-tomodachi-service)
     - [Changing Dockerfile location](#changing-dockerfile-location)
@@ -35,6 +35,7 @@ It facilitates the use of Docker containers for functional, integration, and end
     - [LocalStack](#localstack)
     - [SFTP](#sftp)
   - [Configuration with environment variables](#configuration-with-environment-variables)
+  - [Changing default Docker network](#changing-default-docker-network)
   - [Resources and acknowledgements](#resources-and-acknowledgements)
   - [Development](#development)
 
@@ -47,7 +48,7 @@ pip install tomodachi-testcontainers
 pip install tomodachi-testcontainers[sftp]
 ```
 
-## Quickstart and Examples
+## Quickstart and examples
 
 Tomodachi service examples are in [examples/](examples/) folder. Their end-to-end tests are in [tests/test_services](tests/test_services).
 
@@ -155,10 +156,6 @@ Examples:
 
 - `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH=examples/` - specify just a directory, Dockerfile is inferred automatically
 - `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH=examples/Dockerfile.testing` - explicitly specify the Dockerfile name
-
-⚠️ Make sure that the environment variable is set before running `pytest` -
-e.g. with [pytest-env](https://pypi.org/project/pytest-env/) plugin or
-by setting it in the shell before running `pytest`.
 
 ### Running Tomodachi container from pre-built image
 
@@ -481,11 +478,26 @@ DockerHub: <https://hub.docker.com/r/atmoz/sftp>
 
 ## Configuration with environment variables
 
+⚠️ Make sure that environment variables are set before running `pytest` -
+e.g. with [pytest-env](https://pypi.org/project/pytest-env/) plugin or
+by setting it in the shell before running `pytest`.
+
 | Environment Variable                      | Description                                                                                                                   |
 | :---------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
 | `TESTCONTAINER_DOCKER_NETWORK`            | Launch testcontainers in specified Docker network. Defaults to 'bridge'. Network must be created beforehand                   |
 | `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH` | Override path to Dockerfile for building Tomodachi service image. Defaults to '.'                                             |
 | `<CONTAINER-NAME>_TESTCONTAINER_IMAGE_ID` | Override any supported Testcontainer Image ID. Defaults to `None`, `TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH` takes precedence |
+
+## Changing default Docker network
+
+By default, testcontainers are started in the default `bridge` Docker network.
+Sometimes it's useful to start containers in a different network, e.g. a network
+specifically dedicated for running automated tests.
+
+Specify a new network name with the `TOMODACHI_TESTCONTAINER_NETWORK` environment variable.
+The Docker network is not created automatically, so make sure that it exists before running tests.
+
+⚠️ Make sure that the environment variable is set before running `pytest`.
 
 ## Resources and acknowledgements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,13 @@ asyncssh = { version = "^2.13.2", optional = true }
 pytest = "^7.1.2"
 pytest-asyncio = "^0.21.1"
 testcontainers = "^3.7.1"
-types-aiobotocore = { extras = ["dynamodb", "s3", "sns", "sqs", "ssm"], version = "^2.5.2" }
+types-aiobotocore = { extras = [
+    "dynamodb",
+    "s3",
+    "sns",
+    "sqs",
+    "ssm",
+], version = "^2.5.2" }
 
 [tool.poetry.group.dev.dependencies]
 autoflake = "^2.2.0"
@@ -78,27 +84,51 @@ exclude = '\.git/|\.mypy_cache/|\.venv/|\.pytest_cache/|\.vscode/|__pycache__/|b
 [tool.isort]
 profile = "black"
 line_length = 120
-skip = [".git", ".ruff_cache", ".mypy_cache", ".venv", ".pytest_cache", ".vscode", "__pycache__", "build", "dist"]
+skip = [
+    ".git",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".venv",
+    ".pytest_cache",
+    ".vscode",
+    "__pycache__",
+    "build",
+    "dist",
+]
 
 [tool.bandit]
-exclude_dirs = ["tests", ".git", ".ruff_cache", ".mypy_cache", ".venv", ".pytest_cache", ".vscode", "__pycache__", "build", "dist"]
+exclude_dirs = [
+    "tests",
+    ".git",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".venv",
+    ".pytest_cache",
+    ".vscode",
+    "__pycache__",
+    "build",
+    "dist",
+]
 
 [tool.mypy]
 python_version = "3.8"
 ignore_missing_imports = true
 
 [tool.flake8]
-ignore = [
-    "ANN101",
-    "ANN401",
-    "BLK100",
-    "E501",
-    "LIT101",
-    "PL123",
-]
+ignore = ["ANN101", "ANN401", "BLK100", "E501", "LIT101", "PL123"]
 literal-inline-quotes = "double"
 literal-multiline-quotes = "double"
-exclude = [".git", ".ruff_cache", ".mypy_cache", ".venv", ".pytest_cache", ".vscode", "__pycache__", "build", "dist"]
+exclude = [
+    ".git",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".venv",
+    ".pytest_cache",
+    ".vscode",
+    "__pycache__",
+    "build",
+    "dist",
+]
 
 [tool.ruff]
 target-version = "py38"
@@ -130,15 +160,10 @@ line-length = 120
 [tool.pytest.ini_options]
 minversion = "7.0"
 junit_family = "xunit2"
-testpaths = [
-    "tests"
-]
-norecursedirs = [
-    ".venv",
-    "__pycache__",
-    ".git"
-]
+testpaths = ["tests"]
+norecursedirs = [".venv", "__pycache__", ".git"]
 log_cli_level = "INFO"
 env = [
-    "TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH=examples/Dockerfile"
+    "TESTCONTAINER_DOCKER_NETWORK=tomodachi-testcontainers",
+    "TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH=examples/Dockerfile",
 ]

--- a/src/tomodachi_testcontainers/containers/localstack.py
+++ b/src/tomodachi_testcontainers/containers/localstack.py
@@ -1,9 +1,9 @@
 import os
 from typing import Any, Optional
 
-from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from tomodachi_testcontainers.containers.common import DockerContainer
 from tomodachi_testcontainers.utils import AWSClientConfig
 
 
@@ -27,8 +27,8 @@ class LocalStackContainer(DockerContainer):
         self.with_bind_ports(self.internal_port, self.edge_port)
 
     def get_internal_url(self) -> str:
-        bridge_ip = self.get_docker_client().bridge_ip(self.get_wrapped_container().id)
-        return f"http://{bridge_ip}:{self.internal_port}"
+        ip = self.get_container_internal_ip()
+        return f"http://{ip}:{self.internal_port}"
 
     def get_external_url(self) -> str:
         host = self.get_container_host_ip()

--- a/src/tomodachi_testcontainers/containers/moto.py
+++ b/src/tomodachi_testcontainers/containers/moto.py
@@ -1,9 +1,9 @@
 import os
 from typing import Any, Optional
 
-from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from tomodachi_testcontainers.containers.common import DockerContainer
 from tomodachi_testcontainers.utils import AWSClientConfig
 
 
@@ -30,8 +30,8 @@ class MotoContainer(DockerContainer):
         self.with_env("AWS_SECRET_ACCESS_KEY", self.aws_secret_access_key)
 
     def get_internal_url(self) -> str:
-        bridge_ip = self.get_docker_client().bridge_ip(self.get_wrapped_container().id)
-        return f"http://{bridge_ip}:{self.internal_port}"
+        ip = self.get_container_internal_ip()
+        return f"http://{ip}:{self.internal_port}"
 
     def get_external_url(self) -> str:
         host = self.get_container_host_ip()

--- a/src/tomodachi_testcontainers/containers/sftp.py
+++ b/src/tomodachi_testcontainers/containers/sftp.py
@@ -1,8 +1,9 @@
 from typing import Any, NamedTuple
 
 import asyncssh
-from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
+
+from tomodachi_testcontainers.containers.common import DockerContainer
 
 ConnectionDetails = NamedTuple("ConnectionDetails", [("host", str), ("port", int)])
 
@@ -26,7 +27,7 @@ class SFTPContainer(DockerContainer):
         self.authorized_public_key = self.authorized_private_key.export_public_key().decode()
 
     def get_internal_conn_details(self) -> ConnectionDetails:
-        host = self.get_docker_client().bridge_ip(self.get_wrapped_container().id)
+        host = self.get_container_internal_ip()
         return ConnectionDetails(host=host, port=self.internal_port)
 
     def get_external_conn_details(self) -> ConnectionDetails:

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
+
+from tomodachi_testcontainers.containers.common import DockerContainer
 
 
 class TomodachiContainer(DockerContainer):
@@ -12,8 +13,8 @@ class TomodachiContainer(DockerContainer):
         self.with_bind_ports(internal_port, edge_port)
 
     def get_internal_url(self) -> str:
-        bridge_ip = self.get_docker_client().bridge_ip(self.get_wrapped_container().id)
-        return f"http://{bridge_ip}:{self.internal_port}"
+        ip = self.get_container_internal_ip()
+        return f"http://{ip}:{self.internal_port}"
 
     def get_external_url(self) -> str:
         host = self.get_container_host_ip()


### PR DESCRIPTION
Sometimes testcontainers need to run in another Docker network other than `bridge`, e.g. for isolation.

Allow testcontainer network configuration with envvar `TESTCONTAINER_DOCKER_NETWORK`