### PR TITLE
Pull Docker image if not found locally when using envvar override

### DIFF
--- a/src/tomodachi_testcontainers/containers/common.py
+++ b/src/tomodachi_testcontainers/containers/common.py
@@ -58,4 +58,4 @@ def get_docker_image(image_id: str, docker_client_kw: Optional[Dict] = None) -> 
     try:
         return cast(DockerImage, client.client.images.get(image_id))
     except ImageNotFound:
-        return None
+        return cast(DockerImage, client.client.images.pull(image_id))

--- a/tests/test_fixtures/test_localstack_fixtures.py
+++ b/tests/test_fixtures/test_localstack_fixtures.py
@@ -15,10 +15,7 @@ def test_localstack_image_name_set_from_envvar(pytester: pytest.Pytester) -> Non
             """\
             import os
 
-            from testcontainers.core.docker_client import DockerClient
 
-
-            DockerClient().client.images.pull("localstack/localstack:2.0")
             os.environ["LOCALSTACK_TESTCONTAINER_IMAGE_ID"] = "localstack/localstack:2.0"
             """
         )

--- a/tests/test_fixtures/test_moto_fixtures.py
+++ b/tests/test_fixtures/test_moto_fixtures.py
@@ -15,10 +15,7 @@ def test_moto_image_name_set_from_envvar(pytester: pytest.Pytester) -> None:
             """\
             import os
 
-            from testcontainers.core.docker_client import DockerClient
 
-
-            DockerClient().client.images.pull("motoserver/moto:4.1.0")
             os.environ["MOTO_TESTCONTAINER_IMAGE_ID"] = "motoserver/moto:4.1.0"
             """
         )

--- a/tests/test_fixtures/test_sftp_fixtures.py
+++ b/tests/test_fixtures/test_sftp_fixtures.py
@@ -15,10 +15,7 @@ def test_sftp_image_name_set_from_envvar(pytester: pytest.Pytester) -> None:
             """\
             import os
 
-            from testcontainers.core.docker_client import DockerClient
 
-
-            DockerClient().client.images.pull("atmoz/sftp:alpine-3.4")
             os.environ["SFTP_TESTCONTAINER_IMAGE_ID"] = "atmoz/sftp:alpine-3.4"
             """
         )

--- a/tests/test_fixtures/test_tomodachi_fixures.py
+++ b/tests/test_fixtures/test_tomodachi_fixures.py
@@ -9,10 +9,7 @@ def test_tomodachi_image_id_set_from_envvar(pytester: pytest.Pytester) -> None:
             """\
             import os
 
-            from testcontainers.core.docker_client import DockerClient
 
-
-            DockerClient().client.images.pull("alpine:3.18.2")
             os.environ["TOMODACHI_TESTCONTAINER_IMAGE_ID"] = "alpine:3.18.2"
             """
         )


### PR DESCRIPTION
When using `<CONTAINER-NAME>_TESTCONTAINER_IMAGE_ID` envvar, pull the Docker image if not exists locally