### PR TITLE
Forward container logs on teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It facilitates the use of Docker containers for functional, integration, and end
     - [SFTP](#sftp)
   - [Configuration with environment variables](#configuration-with-environment-variables)
   - [Changing default Docker network](#changing-default-docker-network)
+  - [Forward Testcontainer logs to Pytest](#forward-testcontainer-logs-to-pytest)
   - [Resources and acknowledgements](#resources-and-acknowledgements)
   - [Development](#development)
 
@@ -504,6 +505,18 @@ Specify a new network name with the `TOMODACHI_TESTCONTAINER_NETWORK` environmen
 The Docker network is not created automatically, so make sure that it exists before running tests.
 
 ⚠️ Make sure that the environment variable is set before running `pytest`.
+
+## Forward Testcontainer logs to Pytest
+
+Logs from a testcontainer are forwarded to Python's standard logger as `INFO` logs when
+`tomodachi_testcontainers.containers.DockerContainer` context manager exit.
+
+To see the logs in Pytest, set the log level to at least `INFO` in [Pytest configuration](https://docs.pytest.org/en/7.1.x/how-to/logging.html).
+
+```toml
+[tool.pytest.ini_options]
+log_level = "INFO"
+```
 
 ## Resources and acknowledgements
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,4 +41,3 @@
 ## Testing
 
 - [ ] Docker-from-Docker test
-- [ ] Forward container logs to pytest stdout, otherwise if a test fails, it's hard to debug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,8 @@ minversion = "7.0"
 junit_family = "xunit2"
 testpaths = ["tests"]
 norecursedirs = [".venv", "__pycache__", ".git"]
-log_cli_level = "INFO"
+log_auto_indent = true
+log_level = "INFO"
 env = [
     # Set dummy AWS credentials so that we don't accidentally mutate real infrastructure
     "AWS_DEFAULT_REGION=us-east-1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ exclude = [
 line-length = 120
 
 [tool.pytest.ini_options]
-norecursedirs = [".venv", "__pycache__", ".git"]
 log_level = "INFO"
 env = [
     # Set dummy AWS credentials so that we don't accidentally mutate real infrastructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,7 @@ exclude = [
 line-length = 120
 
 [tool.pytest.ini_options]
-minversion = "7.0"
-junit_family = "xunit2"
-testpaths = ["tests"]
 norecursedirs = [".venv", "__pycache__", ".git"]
-log_auto_indent = true
 log_level = "INFO"
 env = [
     # Set dummy AWS credentials so that we don't accidentally mutate real infrastructure

--- a/src/tomodachi_testcontainers/containers/__init__.py
+++ b/src/tomodachi_testcontainers/containers/__init__.py
@@ -1,6 +1,6 @@
 import contextlib
 
-from tomodachi_testcontainers.containers.common import EphemeralDockerImage, get_docker_image
+from tomodachi_testcontainers.containers.common import DockerContainer, EphemeralDockerImage, get_docker_image
 from tomodachi_testcontainers.containers.localstack import LocalStackContainer
 from tomodachi_testcontainers.containers.moto import MotoContainer
 from tomodachi_testcontainers.containers.tomodachi import TomodachiContainer
@@ -10,6 +10,7 @@ with contextlib.suppress(ModuleNotFoundError):
 
 
 __all__ = [
+    "DockerContainer",
     "EphemeralDockerImage",
     "LocalStackContainer",
     "MotoContainer",

--- a/src/tomodachi_testcontainers/containers/common.py
+++ b/src/tomodachi_testcontainers/containers/common.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess  # nosec: B404
 from pathlib import Path
@@ -14,6 +15,13 @@ class DockerContainer(testcontainers.core.container.DockerContainer):
     def __init__(self, *args: Any, network: Optional[str] = None, **kwargs: Any) -> None:
         self.network = network or os.getenv("TESTCONTAINER_DOCKER_NETWORK") or "bridge"
         super().__init__(*args, **kwargs, network=self.network)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        logger = logging.getLogger(self.__class__.__name__)
+        logs = self.get_wrapped_container().logs(timestamps=True).decode().split("\n")
+        for log in logs:
+            logger.info(log)
+        self.stop()
 
     def get_container_host_ip(self) -> str:
         host = self.get_docker_client().host()

--- a/tests/containers/test_common.py
+++ b/tests/containers/test_common.py
@@ -5,7 +5,7 @@ from typing import Generator
 import pytest
 from docker.errors import BuildError, ImageNotFound
 
-from tomodachi_testcontainers.containers.common import EphemeralDockerImage, get_docker_image
+from tomodachi_testcontainers.containers import EphemeralDockerImage, get_docker_image
 
 
 class TestEphemeralDockerImage:

--- a/tests/pytest/test_tomodachi_fixures.py
+++ b/tests/pytest/test_tomodachi_fixures.py
@@ -20,7 +20,7 @@ def test_tomodachi_image_id_set_from_envvar(pytester: pytest.Pytester) -> None:
             """\
             from docker.models.images import Image as DockerImage
 
-            from tomodachi_testcontainers.containers.common import get_docker_image
+            from tomodachi_testcontainers.containers import get_docker_image
 
 
             def test_tomodachi_image_id_set_from_envvar(tomodachi_image: DockerImage) -> None:

--- a/tests/services/test_service_healthcheck.py
+++ b/tests/services/test_service_healthcheck.py
@@ -29,4 +29,4 @@ async def test_healthcheck_passes(http_client: httpx.AsyncClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
-    assert False
+    pytest.fail("Test failure")

--- a/tests/services/test_service_healthcheck.py
+++ b/tests/services/test_service_healthcheck.py
@@ -29,3 +29,4 @@ async def test_healthcheck_passes(http_client: httpx.AsyncClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+    assert False

--- a/tests/services/test_service_healthcheck.py
+++ b/tests/services/test_service_healthcheck.py
@@ -29,4 +29,3 @@ async def test_healthcheck_passes(http_client: httpx.AsyncClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
-    pytest.fail("Test failure")


### PR DESCRIPTION
When a test fails, we want to see container logs printed in pytest, so that we can immediately tell what went wrong

Logs are printed before container is stopped, which will work nicely on a pytest fixture teardown