### PR TITLE
Log container URLs on start

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -79,7 +79,8 @@ disable=missing-module-docstring,
         redefined-builtin,
         unused-argument,
         unspecified-encoding,
-        no-name-in-module
+        no-name-in-module,
+        logging-fstring-interpolation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/tomodachi_testcontainers/containers/moto.py
+++ b/src/tomodachi_testcontainers/containers/moto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import Any, Optional
 
@@ -34,6 +36,10 @@ class MotoContainer(DockerContainer):
         # Docker is needed for running AWS Lambda container
         self.with_env("MOTO_DOCKER_NETWORK_NAME", self.network)
         self.with_volume_mapping("/var/run/docker.sock", "/var/run/docker.sock")
+
+    def __enter__(self) -> MotoContainer:
+        self.logger.info(f"Moto dashboard: http://localhost:{self.edge_port}/moto-api")
+        return self.start()
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import urllib.parse
 from typing import Any, Optional
 
@@ -20,6 +22,10 @@ class TomodachiContainer(DockerContainer):
         self.edge_port = edge_port
         self.http_healthcheck_path = http_healthcheck_path
         self.with_bind_ports(internal_port, edge_port)
+
+    def __enter__(self) -> TomodachiContainer:
+        self.logger.info(f"Tomodachi service: http://localhost:{self.edge_port}")
+        return self.start()
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()

--- a/src/tomodachi_testcontainers/containers/wiremock.py
+++ b/src/tomodachi_testcontainers/containers/wiremock.py
@@ -2,6 +2,8 @@
 
 Adaptation of https://github.com/wiremock/python-wiremock
 """
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +36,10 @@ class WireMockContainer(DockerContainer):
 
         if verbose:
             self.with_command("--verbose")
+
+    def __enter__(self) -> WireMockContainer:
+        self.logger.info(f"Wiremock admin: http://localhost:{self.edge_port}/__admin")
+        return self.start()
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()

--- a/src/tomodachi_testcontainers/utils.py
+++ b/src/tomodachi_testcontainers/utils.py
@@ -1,3 +1,4 @@
+import logging
 from socket import socket
 from typing import TypedDict
 
@@ -13,3 +14,17 @@ def get_available_port() -> int:
     with socket() as sock:
         sock.bind(("", 0))
         return int(sock.getsockname()[1])
+
+
+def setup_logger(name: str) -> logging.Logger:
+    """Outputs logs to stderr for better visibility in pytest output.
+
+    Inspired by testcontainers.core.utils.setup_logger
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter(fmt="%(name)s: %(message)s"))
+    logger.addHandler(handler)
+    return logger


### PR DESCRIPTION
For easier debugging, log container URL on start, e.g. `Moto dashboard: http://localhost:1234/moto-api`.
That way you can jump to Moto dashboard directly from the IDE debugger.

Logs are now printed to stderr as it's done in `testcontainers.core.utils.setup_logger` - for better visibility in pytest during debugging