### PR TITLE
Support tomodachi 0.26.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2338,24 +2338,25 @@ files = [
 
 [[package]]
 name = "tomodachi"
-version = "0.25.1"
+version = "0.26.0"
 description = "Microservice library on asyncio - HTTP server, websockets, pub/sub messaging for AWS SNS+SQS and RabbitMQ"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "tomodachi-0.25.1-py3-none-any.whl", hash = "sha256:2014c37338c5968e052db6c27c7c7ef481daa9ddd8faea6a340d5f3dd0821192"},
-    {file = "tomodachi-0.25.1.tar.gz", hash = "sha256:52e7a0aaf1297d546ed062afbb4743be33cac2a4e423a806cb6fc6f7e07f856a"},
+    {file = "tomodachi-0.26.0-py3-none-any.whl", hash = "sha256:d7c6f328bef7a0144a372af1cb57ebc0f4674b23b34fe732851da3f4585812a8"},
+    {file = "tomodachi-0.26.0.tar.gz", hash = "sha256:3a800c02eaaf66e67d0957b445f3e1dd76937a85359b0dd594e38b53630ccdfc"},
 ]
 
 [package.dependencies]
 aioamqp = ">=0.13.0,<0.16.0"
-aiobotocore = ">=1.3.0,<2.6.0"
-aiohttp = ">=3.5.4,<3.9.0"
+aiobotocore = ">=1.3.0,<2.7.0"
+aiohttp = ">=3.7.0,<3.9.0"
 asahi = ">=0.1,<0.3"
 botocore = ">=1.20.106"
 cchardet = {version = ">=2.1.7", markers = "python_version < \"3.10\""}
 colorama = ">=0.3.9,<0.5.0"
 pytz = "*"
+structlog = ">=21.5.0,<24.0.0"
 tzlocal = ">=1.4,<6.0"
 
 [package.extras]
@@ -2365,6 +2366,8 @@ aws = ["asahi-extras"]
 brotli = ["Brotli (>=1.0.9,<2.0.0)"]
 color = ["asahi-extras"]
 http = ["asahi-extras"]
+opentelemetry = ["opentelemetry-api (>=1.19.0,<1.20.0)", "opentelemetry-exporter-otlp (>=1.19.0,<1.20)", "opentelemetry-instrumentation (==0.40b0)", "opentelemetry-sdk (>=1.19.0,<1.20.0)", "opentelemetry-util-http (==0.40b0)"]
+opentelemetry-exporter-prometheus = ["opentelemetry-api (>=1.19.0,<1.20.0)", "opentelemetry-exporter-otlp (>=1.19.0,<1.20)", "opentelemetry-exporter-prometheus (==1.12.0rc1)", "opentelemetry-instrumentation (==0.40b0)", "opentelemetry-sdk (>=1.19.0,<1.20.0)", "opentelemetry-util-http (==0.40b0)"]
 protobuf = ["protobuf (>=3.20.0)"]
 scheduler = ["asahi-extras"]
 uvloop = ["uvloop (>=0.14.0,<1.0.0)"]
@@ -3163,4 +3166,4 @@ sftp = ["asyncssh"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "894b43b0ea3a2446ade5d14f8f1a0e3f49810b4f24513fafe6fd14d75f39694c"
+content-hash = "f96de9f5bb8b0bcaa8a2ce971fab7de45dc1d697ce98a29e2c76c2dcfae970e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ pytest-cov = "^4.1.0"
 pytest-env = "^0.8.2"
 ruff = ">=0.0.277,<0.0.283"
 structlog = "^23.1.0"
-tomodachi = "^0.25.1"
+tomodachi = "^0.26.0"
 types-protobuf = "^4.23.0.2"
 types-requests = "^2.31.0.2"
 


### PR DESCRIPTION
tomodachi 0.26.0 changed it's startup log message

```
tomodachi < 0.26.0 - "Started service"
tomodachi >= 0.26.0 - "started service successfully"
```

Adding support for finding both messages on `TomodachiContainer` start, and also making `wait_for_log` mandatory

Apart from HTTP healthcheck, we need to wait for "started service" log to make sure messaging transport like AWS SNS SQS is also up and running. It's started independently from HTTP transport.