### PR TITLE
Clarify SNSSQSTestClient.subscribe_to 'subscribe_attributes' argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ describes a useful [rule of thumb for use of different types of tests](https://w
 
 - **Write the bulk of your tests against the service layer; maintain a small core of tests written against your domain model** -
   if you keep your application business logic use cases decoupled from the framework,
-  you can test most of the system without the need to rely on slow, read dependencies.
+  you can test most of the system without the need to rely on slow, real dependencies.
   You can use fakes for simulating input/output (databases, message brokers, external system adapters),
   making the tests focused on the business logic.
 
@@ -554,7 +554,7 @@ log_level = "INFO"
 
 - Talk ["Integration tests are needed and simple"](https://softwaregarden.dev/en/talks/integration-tests-are-needed-and-simple/)
   by [Piotr Przybyl](https://softwaregarden.dev/en/) - explains the why behind the need
-  for integration testing with read dependencies and gives a demo on Testcontainers.
+  for integration testing with real dependencies and gives a demo on Testcontainers.
 
 - [tomodachi-testcontainers-github-actions](https://github.com/filipsnastins/tomodachi-testcontainers-github-actions) -
   example of running Testcontainers in the CI pipeline.

--- a/src/tomodachi_testcontainers/clients/snssqs_client.py
+++ b/src/tomodachi_testcontainers/clients/snssqs_client.py
@@ -47,7 +47,9 @@ class SNSSQSTestClient:
         self.sns_client = sns_client
         self.sqs_client = sqs_client
 
-    async def subscribe_to(self, topic: str, queue: str, attributes: Optional[Mapping[str, str]] = None) -> None:
+    async def subscribe_to(
+        self, topic: str, queue: str, subscribe_attributes: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Subscribe a SQS queue to a SNS topic; create the topic and queue if they don't exist."""
         list_topics_response = await self.sns_client.list_topics()
         topic_arn = next((v["TopicArn"] for v in list_topics_response["Topics"] if v["TopicArn"].endswith(topic)), None)
@@ -64,7 +66,10 @@ class SNSSQSTestClient:
         queue_arn = get_queue_attributes_response["Attributes"]["QueueArn"]
 
         await self.sns_client.subscribe(
-            TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn, Attributes=attributes or {}
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            Attributes=subscribe_attributes or {},
         )
 
     async def receive(

--- a/tests/clients/test_snssqs_client.py
+++ b/tests/clients/test_snssqs_client.py
@@ -49,7 +49,7 @@ async def test_publish_and_receive_with_message_attributes(snssqs_test_client: S
     await snssqs_test_client.subscribe_to(
         topic="test-topic",
         queue="test-queue",
-        attributes={"FilterPolicy": json.dumps({"MyMessageAttribute": ["will-be-included"]})},
+        subscribe_attributes={"FilterPolicy": json.dumps({"MyMessageAttribute": ["will-be-included"]})},
     )
 
     await snssqs_test_client.publish(


### PR DESCRIPTION
Renaming `attributes` argument to `subscribe_attributes`