### PR TITLE
Forward container logs on startup failure

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,7 +53,7 @@ jobs:
         run: SKIP=test poetry run hooks
 
       - name: Create Docker network for running Testcontianers
-        run: docker network ls | grep ${{ env.TESTCONTAINER_DOCKER_NETWORK }} || docker network create ${{ env.TESTCONTAINER_DOCKER_NETWORK }}
+        run: docker network create ${{ env.TESTCONTAINER_DOCKER_NETWORK }}
 
       - name: Run tests
         run: poetry run test-ci

--- a/src/tomodachi_testcontainers/containers/moto.py
+++ b/src/tomodachi_testcontainers/containers/moto.py
@@ -39,7 +39,8 @@ class MotoContainer(DockerContainer):
 
     def __enter__(self) -> MotoContainer:
         self.logger.info(f"Moto dashboard: http://localhost:{self.edge_port}/moto-api")
-        return self.start()
+        super().__enter__()
+        return self
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -26,7 +26,8 @@ class TomodachiContainer(DockerContainer):
 
     def __enter__(self) -> TomodachiContainer:
         self.logger.info(f"Tomodachi service: http://localhost:{self.edge_port}")
-        return self.start()
+        super().__enter__()
+        return self
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()
@@ -41,7 +42,6 @@ class TomodachiContainer(DockerContainer):
         if self.http_healthcheck_path:
             url = urllib.parse.urljoin(self.get_external_url(), self.http_healthcheck_path)
             wait_for_http_healthcheck(url=url, timeout=timeout, interval=interval, status_code=status_code)
-
         # Apart from HTTP healthcheck, we need to wait for "started service" log
         # to make sure messaging transport like AWS SNS SQS is also up and running.
         # It's started independently from HTTP transport.

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -42,6 +42,7 @@ class TomodachiContainer(DockerContainer):
         if self.http_healthcheck_path:
             url = urllib.parse.urljoin(self.get_external_url(), self.http_healthcheck_path)
             wait_for_http_healthcheck(url=url, timeout=timeout, interval=interval, status_code=status_code)
+
         # Apart from HTTP healthcheck, we need to wait for "started service" log
         # to make sure messaging transport like AWS SNS SQS is also up and running.
         # It's started independently from HTTP transport.

--- a/src/tomodachi_testcontainers/containers/wiremock.py
+++ b/src/tomodachi_testcontainers/containers/wiremock.py
@@ -40,7 +40,8 @@ class WireMockContainer(DockerContainer):
 
     def __enter__(self) -> WireMockContainer:
         self.logger.info(f"Wiremock admin: http://localhost:{self.edge_port}/__admin")
-        return self.start()
+        super().__enter__()
+        return self
 
     def get_internal_url(self) -> str:
         ip = self.get_container_internal_ip()


### PR DESCRIPTION
If a container fails to start, container logs must be forwarded to the logger for debugging