### PR TITLE
🐛 bug: remove container on failed healthcheck; forward container logs only in context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ in the example below.
 from typing import Generator, cast
 
 import pytest
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 
 from tomodachi_testcontainers import LocalStackContainer, TomodachiContainer
 from tomodachi_testcontainers.utils import get_available_port
@@ -284,7 +284,7 @@ from tomodachi_testcontainers.utils import get_available_port
 
 @pytest.fixture()
 def tomodachi_container(
-    testcontainers_docker_image: DockerImage,
+    testcontainers_docker_image: Image,
     localstack_container: LocalStackContainer,
 ) -> Generator[TomodachiContainer, None, None]:
     with (

--- a/poetry.lock
+++ b/poetry.lock
@@ -2194,7 +2194,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2202,15 +2201,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2227,7 +2219,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2235,7 +2226,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2322,6 +2312,17 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "shortuuid"
+version = "1.0.11"
+description = "A generator library for concise, unambiguous and URL-safe UUIDs."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "shortuuid-1.0.11-py3-none-any.whl", hash = "sha256:27ea8f28b1bd0bf8f15057a3ece57275d2059d2b0bb02854f02189962c13b6aa"},
+    {file = "shortuuid-1.0.11.tar.gz", hash = "sha256:fc75f2615914815a8e4cb1501b3a513745cb66ef0fd5fc6fb9f8c3fa3481f789"},
+]
 
 [[package]]
 name = "six"
@@ -3381,4 +3382,4 @@ sftp = ["asyncssh"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2ef43cb5f72934e1c713e4498f7b9456880c851e35c1882601987aa95f1468b0"
+content-hash = "1967d70acf76ec47e0801b312113d710b6142011600b859833fb9deb14189fb7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pymysql = { version = "^1.1.0", optional = true }
 pytest = "^7.1.2"
 pytest-asyncio = "^0.21.1"
 requests = "^2.31.0"
+shortuuid = "^1.0.11"
 sqlalchemy = { version = ">=1.3,<3", optional = true }
 tenacity = "^8.2.2"
 testcontainers = "^3.7.1"

--- a/src/tomodachi_testcontainers/containers/common/container.py
+++ b/src/tomodachi_testcontainers/containers/common/container.py
@@ -1,18 +1,24 @@
 import abc
 import contextlib
+import logging
 import os
 from types import TracebackType
 from typing import Any, Dict, Optional, Type
 
+import shortuuid
 import testcontainers.core.container
+from docker.models.containers import Container
 from testcontainers.core.utils import inside_container
 
 from tomodachi_testcontainers.utils import setup_logger
 
 
 class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
+    _container: Optional[Container]
+    _name: str
+    _logger: logging.Logger
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._logger = setup_logger(self.__class__.__name__)
         self.network = os.getenv("TESTCONTAINER_DOCKER_NETWORK") or "bridge"
         super().__init__(*args, **kwargs, network=self.network)
 
@@ -32,7 +38,7 @@ class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
 
     @abc.abstractmethod
     def log_message_on_container_start(self) -> str:
-        pass  # pragma: no cover
+        """Returns a message that will be logged when the container starts."""
 
     def get_container_host_ip(self) -> str:
         host = self.get_docker_client().host()
@@ -55,6 +61,28 @@ class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
         return self.get_docker_client().get_container(self.get_wrapped_container().id)
 
     def start(self) -> "DockerContainer":
+        self._set_container_name()
+        self._setup_logger()
+        self._start()
+        self._log_message_on_container_start()
+        return self
+
+    def stop(self) -> None:
+        if self._container is not None:
+            with contextlib.suppress(Exception):
+                self.get_wrapped_container().remove(force=True, v=True)
+            self._container = None
+
+    def restart(self) -> None:
+        self.get_wrapped_container().restart()
+
+    def _set_container_name(self) -> None:
+        self._name = self._name or shortuuid.uuid()
+
+    def _setup_logger(self) -> None:
+        self._logger = setup_logger(f"{self.__class__.__name__} ({self._name})")
+
+    def _start(self) -> None:
         self._logger.info(f"Pulling image: {self.image}")
         self._container = self.get_docker_client().run(
             image=self.image,
@@ -66,19 +94,11 @@ class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
             volumes=self.volumes,
             **self._kwargs,
         )
-        self._logger.info(f"Container started: {self._container.short_id}")
+        self._logger.info(f"Container started: {self._name}")
+
+    def _log_message_on_container_start(self) -> None:
         if message := self.log_message_on_container_start():
             self._logger.info(message)
-        return self
-
-    def stop(self) -> None:
-        if self._container is not None:
-            with contextlib.suppress(Exception):
-                self.get_wrapped_container().remove(force=True, v=True)
-            self._container = None
-
-    def restart(self) -> None:
-        self.get_wrapped_container().restart()
 
     def _forward_container_logs_to_logger(self) -> None:
         if container := self.get_wrapped_container():

--- a/src/tomodachi_testcontainers/containers/common/image.py
+++ b/src/tomodachi_testcontainers/containers/common/image.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from types import TracebackType
 from typing import Dict, Iterator, Optional, Tuple, Type, cast
 
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 from testcontainers.core.docker_client import DockerClient
 
 
 class EphemeralDockerImage:
     """Builds a Docker image from a given Dockerfile and removes it when the context manager exits."""
 
-    image: DockerImage
+    image: Image
 
     def __init__(
         self,
@@ -25,7 +25,7 @@ class EphemeralDockerImage:
         self.target = target
         self._docker_client = DockerClient(**(docker_client_kwargs or {}))
 
-    def __enter__(self) -> DockerImage:
+    def __enter__(self) -> Image:
         self.build_image()
         return self.image
 
@@ -43,7 +43,7 @@ class EphemeralDockerImage:
     def remove_image(self) -> None:
         self._docker_client.client.images.remove(image=str(self.image.id))
 
-    def _build_with_docker_buildkit(self) -> DockerImage:
+    def _build_with_docker_buildkit(self) -> Image:
         cmd = ["docker", "build", "-q", "--rm=true"]
         if self.dockerfile:
             cmd.extend(["-f", self.dockerfile])
@@ -59,11 +59,11 @@ class EphemeralDockerImage:
             check=True,
         )
         image_id = result.stdout.decode("utf-8").strip()
-        return cast(DockerImage, self._docker_client.client.images.get(image_id))
+        return cast(Image, self._docker_client.client.images.get(image_id))
 
-    def _build_with_docker_client(self) -> DockerImage:
+    def _build_with_docker_client(self) -> Image:
         image, _ = cast(
-            Tuple[DockerImage, Iterator],
+            Tuple[Image, Iterator],
             self._docker_client.client.images.build(
                 dockerfile=self.dockerfile,
                 path=self.context,

--- a/src/tomodachi_testcontainers/containers/common/image.py
+++ b/src/tomodachi_testcontainers/containers/common/image.py
@@ -26,21 +26,21 @@ class EphemeralDockerImage:
         self._docker_client = DockerClient(**(docker_client_kwargs or {}))
 
     def __enter__(self) -> Image:
-        self.build_image()
+        self._build_image()
         return self.image
 
     def __exit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
-        self.remove_image()
+        self._remove_image()
 
-    def build_image(self) -> None:
+    def _build_image(self) -> None:
         if os.getenv("DOCKER_BUILDKIT"):
             self.image = self._build_with_docker_buildkit()
         else:
             self.image = self._build_with_docker_client()
 
-    def remove_image(self) -> None:
+    def _remove_image(self) -> None:
         self._docker_client.client.images.remove(image=str(self.image.id))
 
     def _build_with_docker_buildkit(self) -> Image:

--- a/src/tomodachi_testcontainers/containers/common/web.py
+++ b/src/tomodachi_testcontainers/containers/common/web.py
@@ -18,8 +18,8 @@ class WebContainer(DockerContainer, abc.ABC):
     def __init__(
         self,
         image: str,
-        internal_port: int = 9700,
-        edge_port: int = 9700,
+        internal_port: int,
+        edge_port: int,
         http_healthcheck_path: Optional[str] = None,
         **kwargs: Any,
     ) -> None:

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -1,9 +1,27 @@
+from typing import Any, Optional
+
 from testcontainers.core.waiting_utils import wait_for_logs
 
 from tomodachi_testcontainers.containers.common import WebContainer
 
 
 class TomodachiContainer(WebContainer):
+    def __init__(
+        self,
+        image: str,
+        internal_port: int = 9700,
+        edge_port: int = 9700,
+        http_healthcheck_path: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            image=image,
+            internal_port=internal_port,
+            edge_port=edge_port,
+            http_healthcheck_path=http_healthcheck_path,
+            **kwargs,
+        )
+
     def log_message_on_container_start(self) -> str:
         return f"Tomodachi service: http://localhost:{self.edge_port}"
 

--- a/src/tomodachi_testcontainers/pytest/fixtures/containers.py
+++ b/src/tomodachi_testcontainers/pytest/fixtures/containers.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from typing import Generator
 
 import pytest
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 
 from tomodachi_testcontainers import EphemeralDockerImage
 from tomodachi_testcontainers.utils import get_docker_image
 
 
 @pytest.fixture(scope="session")
-def testcontainers_docker_image() -> Generator[DockerImage, None, None]:
+def testcontainers_docker_image() -> Generator[Image, None, None]:
     if image_id := os.getenv("TOMODACHI_TESTCONTAINER_IMAGE_ID"):
         yield get_docker_image(image_id)
     else:

--- a/src/tomodachi_testcontainers/utils.py
+++ b/src/tomodachi_testcontainers/utils.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, TypedDict, cast
 
 from docker.errors import ImageNotFound
 from docker.models.containers import Container
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 from testcontainers.core.docker_client import DockerClient
 
 
@@ -19,13 +19,13 @@ class AWSClientConfig(TypedDict):
     endpoint_url: str
 
 
-def get_docker_image(image_id: str, docker_client_kwargs: Optional[Dict] = None) -> DockerImage:
+def get_docker_image(image_id: str, docker_client_kwargs: Optional[Dict] = None) -> Image:
     """Returns a Docker image, pulling it if not exists on host."""
     client = DockerClient(**(docker_client_kwargs or {}))
     try:
-        return cast(DockerImage, client.client.images.get(image_id))
+        return cast(Image, client.client.images.get(image_id))
     except ImageNotFound:
-        return cast(DockerImage, client.client.images.pull(image_id))
+        return cast(Image, client.client.images.pull(image_id))
 
 
 def copy_folder_to_container(container: Container, host_path: Path, container_path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import asyncio
-from contextlib import closing
+import contextlib
 from typing import Generator, Iterator, cast
 
 import pytest
@@ -29,7 +29,7 @@ class HTTPBinContainer(WebContainer):
 
 @pytest.fixture(scope="session")
 def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    with closing(asyncio.new_event_loop()) as loop:
+    with contextlib.closing(asyncio.new_event_loop()) as loop:
         yield loop
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,45 +1,13 @@
 import asyncio
 import contextlib
-from typing import Generator, Iterator, cast
+from typing import Iterator
 
 import pytest
 
-from tomodachi_testcontainers import DockerContainer, WebContainer
-from tomodachi_testcontainers.utils import get_available_port
-
 pytest_plugins = ["pytester"]
-
-
-class AlpineContainer(DockerContainer):
-    def __init__(self) -> None:
-        super().__init__(image="alpine:latest")
-        self.with_command("sleep infinity")
-
-    def log_message_on_container_start(self) -> str:
-        return "Alpine container started"
-
-
-class HTTPBinContainer(WebContainer):
-    def __init__(self) -> None:
-        super().__init__(image="kennethreitz/httpbin", internal_port=80, edge_port=get_available_port())
-
-    def log_message_on_container_start(self) -> str:
-        return "HTTPBin container started"
 
 
 @pytest.fixture(scope="session")
 def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     with contextlib.closing(asyncio.new_event_loop()) as loop:
         yield loop
-
-
-@pytest.fixture(scope="session")
-def alpine_container() -> Generator[AlpineContainer, None, None]:
-    with AlpineContainer() as container:
-        yield cast(AlpineContainer, container)
-
-
-@pytest.fixture(scope="session")
-def httpbin_container() -> Generator[HTTPBinContainer, None, None]:
-    with HTTPBinContainer() as container:
-        yield cast(HTTPBinContainer, container)

--- a/tests/containers/common/test_docker_container.py
+++ b/tests/containers/common/test_docker_container.py
@@ -1,0 +1,102 @@
+import docker
+import docker.errors
+import pytest
+import shortuuid
+
+from tomodachi_testcontainers import DockerContainer
+from tomodachi_testcontainers.pytest.async_probes import probe_until
+
+
+class WorkingContainer(DockerContainer):
+    def __init__(self) -> None:
+        super().__init__(image="alpine:latest")
+
+    def log_message_on_container_start(self) -> str:
+        return "Working container started"
+
+
+class FailingContainer(DockerContainer):
+    def __init__(self) -> None:
+        super().__init__(image="alpine:latest")
+
+    def log_message_on_container_start(self) -> str:
+        return "Container with a broken healthcheck started"
+
+    def start(self) -> "FailingContainer":
+        super().start()
+        self.exec("sh -c 'echo \"container startup failed\" >> /proc/1/fd/1'")
+        raise RuntimeError("Failed to start the container")
+
+
+class TestCleanup:
+    def test_container_started(self) -> None:
+        container_name = shortuuid.uuid()
+
+        _ = WorkingContainer().with_command("sleep infinity").with_name(container_name).start()
+
+        assert docker.from_env().containers.get(container_name)
+
+    @pytest.mark.asyncio()
+    async def test_container_removed_on_garbage_collection(self) -> None:
+        container_name = shortuuid.uuid()
+
+        WorkingContainer().with_command("sleep infinity").with_name(container_name).start()
+
+        # Since we don't have a reference (variable) to the container object,
+        # it is eventually garbage collected and removed
+        def _assert_container_removed() -> None:
+            with pytest.raises(docker.errors.NotFound):
+                docker.from_env().containers.get(container_name)
+
+        await probe_until(_assert_container_removed)
+
+    def test_container_removed_on_context_manager_exit(self) -> None:
+        container_name = shortuuid.uuid()
+        with WorkingContainer().with_command("sleep infinity").with_name(container_name):
+            pass
+
+        with pytest.raises(docker.errors.NotFound):
+            docker.from_env().containers.get(container_name)
+
+    def test_container_removed_on_stop(self) -> None:
+        container_name = shortuuid.uuid()
+        container = WorkingContainer().with_command("sleep infinity").with_name(container_name).start()
+
+        container.stop()
+
+        with pytest.raises(docker.errors.NotFound):
+            docker.from_env().containers.get(container_name)
+
+
+class TestLogging:
+    def test_container_logs_are_forwarded_on_context_manager_exit(self, capsys: pytest.CaptureFixture) -> None:
+        with WorkingContainer().with_command("sleep infinity") as container:
+            container.exec("sh -c 'echo \"my log message\" >> /proc/1/fd/1'")
+
+        stderr = str(capsys.readouterr().err)
+        assert "--- Logging error ---" not in stderr  # The error message comes from logger standard library
+        assert "my log message" in stderr
+
+    def test_container_logs_are_forwarded_on_failed_startup(self, capsys: pytest.CaptureFixture) -> None:
+        with pytest.raises(RuntimeError), FailingContainer().with_command("sleep infinity"):
+            pass
+
+        stderr = str(capsys.readouterr().err)
+        assert "--- Logging error ---" not in stderr
+        assert "container startup failed" in stderr
+
+    def test_container_logs_are_not_forwarded_outside_of_context_manager(self, capsys: pytest.CaptureFixture) -> None:
+        container = WorkingContainer().with_command("sleep infinity").start()
+
+        container.exec("sh -c 'echo \"my log message\" >> /proc/1/fd/1'")
+
+        stderr = str(capsys.readouterr().err)
+        assert "--- Logging error ---" not in stderr
+        assert "my log message" not in stderr
+
+    def test_logs_prefixed_with_container_name(self, capsys: pytest.CaptureFixture) -> None:
+        with WorkingContainer().with_command("sleep infinity").with_name("my-container-name"):
+            pass
+
+        stderr = str(capsys.readouterr().err)
+        assert "WorkingContainer (my-container-name): Working container started" in stderr

--- a/tests/containers/common/test_web_container.py
+++ b/tests/containers/common/test_web_container.py
@@ -1,19 +1,35 @@
+from typing import Generator, cast
+
 import pytest
 from requests.exceptions import ConnectionError
 
-from tests.conftest import HTTPBinContainer
+from tomodachi_testcontainers import WebContainer
 from tomodachi_testcontainers.containers.common.web import wait_for_http_healthcheck
 from tomodachi_testcontainers.utils import get_available_port
 
 
+class HTTPBinContainer(WebContainer):
+    def __init__(self) -> None:
+        super().__init__(image="kennethreitz/httpbin", internal_port=80, edge_port=get_available_port())
+
+    def log_message_on_container_start(self) -> str:
+        return "HTTPBin container started"
+
+
+@pytest.fixture(scope="module")
+def httpbin_container() -> Generator[HTTPBinContainer, None, None]:
+    with HTTPBinContainer() as container:
+        yield cast(HTTPBinContainer, container)
+
+
 def test_no_connection_to_host() -> None:
     with pytest.raises(ConnectionError):
-        wait_for_http_healthcheck(f"http://localhost:{get_available_port()}/foo", timeout=1.0)
+        wait_for_http_healthcheck(f"http://localhost:{get_available_port()}/foo", timeout=2.0)
 
 
 def test_healthcheck_returns_http_500(httpbin_container: HTTPBinContainer) -> None:
     with pytest.raises(RuntimeError, match="Healthcheck failed with HTTP status code: 500"):
-        wait_for_http_healthcheck(f"{httpbin_container.get_external_url()}/status/500", timeout=1.0)
+        wait_for_http_healthcheck(f"{httpbin_container.get_external_url()}/status/500", timeout=2.0)
 
 
 def test_healthcheck_returns_http_200(httpbin_container: HTTPBinContainer) -> None:

--- a/tests/pytest/test_containers_fixures.py
+++ b/tests/pytest/test_containers_fixures.py
@@ -18,12 +18,12 @@ def test_testcontainers_docker_image_set_from_envvar(pytester: pytest.Pytester) 
     pytester.makepyfile(
         dedent(
             """\
-            from docker.models.images import Image as DockerImage
+            from docker.models.images import Image
 
             from tomodachi_testcontainers.utils import get_docker_image
 
 
-            def test_testcontainers_docker_image_set_from_envvar(testcontainers_docker_image: DockerImage) -> None:
+            def test_testcontainers_docker_image_set_from_envvar(testcontainers_docker_image: Image) -> None:
                 image = get_docker_image("alpine:3.18.2")
 
                 assert testcontainers_docker_image.id == image.id

--- a/tests/services/test_service_healthcheck.py
+++ b/tests/services/test_service_healthcheck.py
@@ -3,20 +3,17 @@ from typing import AsyncGenerator, Generator, cast
 import httpx
 import pytest
 import pytest_asyncio
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 
 from tomodachi_testcontainers import TomodachiContainer
 from tomodachi_testcontainers.utils import get_available_port
 
 
 @pytest.fixture(scope="module")
-def service_healthcheck_container(
-    testcontainers_docker_image: DockerImage,
-) -> Generator[TomodachiContainer, None, None]:
-    with TomodachiContainer(
-        image=str(testcontainers_docker_image.id),
-        edge_port=get_available_port(),
-    ).with_command("tomodachi run src/healthcheck.py --production") as container:
+def service_healthcheck_container(testcontainers_docker_image: Image) -> Generator[TomodachiContainer, None, None]:
+    with TomodachiContainer(image=str(testcontainers_docker_image.id), edge_port=get_available_port()).with_command(
+        "tomodachi run src/healthcheck.py --production"
+    ) as container:
         yield cast(TomodachiContainer, container)
 
 

--- a/tests/services/test_service_sftp.py
+++ b/tests/services/test_service_sftp.py
@@ -6,7 +6,7 @@ import asyncssh
 import httpx
 import pytest
 import pytest_asyncio
-from docker.models.images import Image as DockerImage
+from docker.models.images import Image
 
 from tomodachi_testcontainers import SFTPContainer, TomodachiContainer
 from tomodachi_testcontainers.utils import get_available_port
@@ -14,7 +14,7 @@ from tomodachi_testcontainers.utils import get_available_port
 
 @pytest.fixture(scope="module")
 def service_sftp_container(
-    testcontainers_docker_image: DockerImage, sftp_container: SFTPContainer
+    testcontainers_docker_image: Image, sftp_container: SFTPContainer
 ) -> Generator[TomodachiContainer, None, None]:
     with (
         TomodachiContainer(

--- a/tests/utils/test_copy_folder_to_container.py
+++ b/tests/utils/test_copy_folder_to_container.py
@@ -1,7 +1,24 @@
 from pathlib import Path
+from typing import Generator, cast
 
-from tests.conftest import AlpineContainer
+import pytest
+
+from tomodachi_testcontainers import DockerContainer
 from tomodachi_testcontainers.utils import copy_folder_to_container
+
+
+class AlpineContainer(DockerContainer):
+    def __init__(self) -> None:
+        super().__init__(image="alpine:latest")
+
+    def log_message_on_container_start(self) -> str:
+        return "Alpine container started"
+
+
+@pytest.fixture(scope="module")
+def alpine_container() -> Generator[AlpineContainer, None, None]:
+    with AlpineContainer().with_command("sleep infinity") as container:
+        yield cast(AlpineContainer, container)
 
 
 def test_copy_folder_to_container(alpine_container: AlpineContainer) -> None:


### PR DESCRIPTION
- New features
  - `DockerContainer`: logs from the container are now prefixed with the container name.
  This makes it easier to distinguish logs from multiple containers,
  especially when using multiple containers of the same type.

- Bug fixes
  - `DockerContainer`: forward container logs to the Python logger only when the `DockerContainer` used as a context manager.
  Otherwise, the logger fails in the `DockerContainer.__del__` method, because the logger instance is already closed.