### PR TITLE
(fix) Cleanup Docker Image when running tests in parallel

### DIFF
--- a/src/tomodachi_testcontainers/containers/common/image.py
+++ b/src/tomodachi_testcontainers/containers/common/image.py
@@ -19,14 +19,11 @@ class EphemeralDockerImage:
         context: Optional[Path] = None,
         target: Optional[str] = None,
         docker_client_kwargs: Optional[Dict] = None,
-        *,
-        remove_image_on_exit: bool = True,
     ) -> None:
         self.dockerfile = str(dockerfile) if dockerfile else None
         self.context = str(context) if context else "."
         self.target = target
         self._docker_client = DockerClient(**(docker_client_kwargs or {}))
-        self._remove_image_on_exit = remove_image_on_exit
 
     def __enter__(self) -> Image:
         return self._build_image()
@@ -34,8 +31,7 @@ class EphemeralDockerImage:
     def __exit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
-        if self._remove_image_on_exit:
-            self._remove_image()
+        self._remove_image()
 
     def _build_image(self) -> Image:
         if os.getenv("DOCKER_BUILDKIT"):

--- a/src/tomodachi_testcontainers/pytest/fixtures/containers.py
+++ b/src/tomodachi_testcontainers/pytest/fixtures/containers.py
@@ -11,6 +11,7 @@ from tomodachi_testcontainers import EphemeralDockerImage
 
 @pytest.fixture(scope="session")
 def testcontainers_docker_image() -> Generator[str, None, None]:
+    # When tests are running in parallel with pytest-xdist
     if os.getenv("PYTEST_XDIST_WORKER"):
         try:
             with _testcontainers_docker_image() as image_id:
@@ -24,6 +25,7 @@ def testcontainers_docker_image() -> Generator[str, None, None]:
                 if exc.response.status_code == 409 and "image is being used by running container" in message:
                     return
             raise
+    # When tests are running sequentially
     else:
         with _testcontainers_docker_image() as image_id:
             yield image_id


### PR DESCRIPTION
Fixes a race condition when tests running in parallel try to delete the same Docker Image in the `testcontainers_docker_image` pytest fixture.

Ignoring the error `image is being used by running container` and letting the last test win the race for the image cleanup.