### PR TITLE
feat(WireMockContainer): add wiremock_container pytest fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,10 @@ env = [
     "TOMODACHI_TESTCONTAINER_DOCKERFILE_PATH=examples/Dockerfile",
     "TOMODACHI_TESTCONTAINER_DOCKER_BUILD_CONTEXT=examples",
     "TOMODACHI_TESTCONTAINER_DOCKER_BUILD_TARGET=test",
+    # WireMock Testcontainer configuration
+    "WIREMOCK_TESTCONTAINER_MAPPING_STUBS=tests/containers/test-wiremock-container/mappings",
+    "WIREMOCK_TESTCONTAINER_MAPPING_FILES=tests/containers/test-wiremock-container/files",
+    "WIREMOCK_TESTCONTAINER_VERBOSE=1",
 ]
 
 [tool.coverage.run]

--- a/src/tomodachi_testcontainers/__init__.py
+++ b/src/tomodachi_testcontainers/__init__.py
@@ -1,24 +1,24 @@
 import contextlib
 
-from tomodachi_testcontainers.containers.common import DockerContainer, EphemeralDockerImage, WebContainer
-from tomodachi_testcontainers.containers.dynamodb_admin import DynamoDBAdminContainer
-from tomodachi_testcontainers.containers.localstack import LocalStackContainer
-from tomodachi_testcontainers.containers.minio import MinioContainer
-from tomodachi_testcontainers.containers.moto import MotoContainer
-from tomodachi_testcontainers.containers.tomodachi import TomodachiContainer
-from tomodachi_testcontainers.containers.wiremock import WireMockContainer
+from .containers.common import DockerContainer, EphemeralDockerImage, WebContainer
+from .containers.dynamodb_admin import DynamoDBAdminContainer
+from .containers.localstack import LocalStackContainer
+from .containers.minio import MinioContainer
+from .containers.moto import MotoContainer
+from .containers.tomodachi import TomodachiContainer
+from .containers.wiremock import WireMockContainer
 
 with contextlib.suppress(ImportError):  # 'db' extra dependency
-    from tomodachi_testcontainers.containers.common import DatabaseContainer
+    from .containers.common import DatabaseContainer
 
 with contextlib.suppress(ImportError):  # 'mysql' extra dependency
-    from tomodachi_testcontainers.containers.mysql import MySQLContainer
+    from .containers.mysql import MySQLContainer
 
 with contextlib.suppress(ImportError):  # 'postgres' extra dependency
-    from tomodachi_testcontainers.containers.postgres import PostgreSQLContainer
+    from .containers.postgres import PostgreSQLContainer
 
 with contextlib.suppress(ImportError):  # 'sftp' extra dependency
-    from tomodachi_testcontainers.containers.sftp import SFTPContainer
+    from .containers.sftp import SFTPContainer
 
 __all__ = [
     "DatabaseContainer",

--- a/src/tomodachi_testcontainers/clients/__init__.py
+++ b/src/tomodachi_testcontainers/clients/__init__.py
@@ -1,4 +1,4 @@
-from tomodachi_testcontainers.clients.snssqs import SNSSQSTestClient
+from .snssqs import SNSSQSTestClient
 
 __all__ = [
     "SNSSQSTestClient",

--- a/src/tomodachi_testcontainers/containers/common/__init__.py
+++ b/src/tomodachi_testcontainers/containers/common/__init__.py
@@ -1,11 +1,11 @@
 import contextlib
 
-from tomodachi_testcontainers.containers.common.container import DockerContainer
-from tomodachi_testcontainers.containers.common.image import EphemeralDockerImage
-from tomodachi_testcontainers.containers.common.web import WebContainer
+from .container import DockerContainer
+from .image import EphemeralDockerImage
+from .web import WebContainer
 
 with contextlib.suppress(ImportError):  # 'db' extra dependency
-    from tomodachi_testcontainers.containers.common.database import DatabaseContainer
+    from .database import DatabaseContainer
 
 __all__ = [
     "DatabaseContainer",

--- a/src/tomodachi_testcontainers/pytest/__init__.py
+++ b/src/tomodachi_testcontainers/pytest/__init__.py
@@ -2,8 +2,8 @@ import contextlib
 
 import pytest
 
-from tomodachi_testcontainers.pytest.fixtures.containers import testcontainers_docker_image
-from tomodachi_testcontainers.pytest.fixtures.localstack import (
+from .fixtures.containers import testcontainers_docker_image
+from .fixtures.localstack import (
     _restart_localstack_container_on_teardown,
     localstack_container,
     localstack_dynamodb_client,
@@ -15,8 +15,8 @@ from tomodachi_testcontainers.pytest.fixtures.localstack import (
     localstack_sqs_client,
     localstack_ssm_client,
 )
-from tomodachi_testcontainers.pytest.fixtures.minio import minio_container, minio_s3_client
-from tomodachi_testcontainers.pytest.fixtures.moto import (
+from .fixtures.minio import minio_container, minio_s3_client
+from .fixtures.moto import (
     _reset_moto_container_on_teardown,
     moto_container,
     moto_dynamodb_client,
@@ -28,15 +28,16 @@ from tomodachi_testcontainers.pytest.fixtures.moto import (
     moto_sqs_client,
     moto_ssm_client,
 )
+from .fixtures.wiremock import wiremock_container
 
 with contextlib.suppress(ImportError):  # 'mysql' extra dependency
-    from tomodachi_testcontainers.pytest.fixtures.mysql import mysql_container
+    from .fixtures.mysql import mysql_container
 
 with contextlib.suppress(ImportError):  # 'postgres' extra dependency
-    from tomodachi_testcontainers.pytest.fixtures.postgres import postgres_container
+    from .fixtures.postgres import postgres_container
 
 with contextlib.suppress(ImportError):  # 'sftp' extra dependency
-    from tomodachi_testcontainers.pytest.fixtures.sftp import sftp_container, userpass_sftp_client, userssh_sftp_client
+    from .fixtures.sftp import sftp_container, userpass_sftp_client, userssh_sftp_client
 
 
 pytest.register_assert_rewrite("tomodachi_testcontainers.pytest.assertions")
@@ -71,4 +72,5 @@ __all__ = [
     "testcontainers_docker_image",
     "userpass_sftp_client",
     "userssh_sftp_client",
+    "wiremock_container",
 ]

--- a/src/tomodachi_testcontainers/pytest/fixtures/wiremock.py
+++ b/src/tomodachi_testcontainers/pytest/fixtures/wiremock.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+from typing import Generator, cast
+
+import pytest
+
+from tomodachi_testcontainers import WireMockContainer
+from tomodachi_testcontainers.utils import get_available_port
+
+try:
+    from wiremock.constants import Config as WireMockConfig
+except ImportError:
+    WireMockConfig = None
+
+
+@pytest.fixture(scope="session")
+def wiremock_container() -> Generator[WireMockContainer, None, None]:
+    image = os.getenv("WIREMOCK_TESTCONTAINER_IMAGE_ID", "wiremock/wiremock:latest")
+    mapping_stubs = os.getenv("WIREMOCK_TESTCONTAINER_MAPPING_STUBS")
+    mapping_files = os.getenv("WIREMOCK_TESTCONTAINER_MAPPING_FILES")
+    verbose = bool(os.getenv("WIREMOCK_TESTCONTAINER_VERBOSE"))
+    with WireMockContainer(
+        image=image,
+        edge_port=get_available_port(),
+        mapping_stubs=Path(mapping_stubs) if mapping_stubs else None,
+        mapping_files=Path(mapping_files) if mapping_files else None,
+        verbose=verbose,
+    ) as container:
+        container = cast(WireMockContainer, container)
+        if WireMockConfig is not None:
+            WireMockConfig.base_url = f"{container.get_external_url()}/__admin/"
+        yield container

--- a/tests/containers/test_wiremock_container.py
+++ b/tests/containers/test_wiremock_container.py
@@ -1,23 +1,8 @@
-from pathlib import Path
-from typing import Generator, cast
-
 import httpx
 import pytest
 import wiremock.client as wm
-from wiremock.constants import Config as WireMockConfig
 
 from tomodachi_testcontainers import WireMockContainer
-from tomodachi_testcontainers.utils import get_available_port
-
-
-@pytest.fixture(scope="module")
-def wiremock_container() -> Generator[WireMockContainer, None, None]:
-    mapping_stubs = Path(__file__).parent / "test-wiremock-container" / "mappings"
-    mapping_files = Path(__file__).parent / "test-wiremock-container" / "files"
-    with WireMockContainer(mapping_stubs, mapping_files, edge_port=get_available_port(), verbose=True) as container:
-        container = cast(WireMockContainer, container)
-        WireMockConfig.base_url = f"{container.get_external_url()}/__admin/"  # WireMock SDK is optional
-        yield container
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
Adding `wiremock_container` pytest fixture.

Configuration environment variables:

```text
WIREMOCK_TESTCONTAINER_IMAGE_ID
WIREMOCK_TESTCONTAINER_MAPPING_STUBS
WIREMOCK_TESTCONTAINER_MAPPING_FILES
WIREMOCK_TESTCONTAINER_VERBOSE
```

If <https://github.com/wiremock/python-wiremock> is installed, it will be automatically configured by the fixture to use the URL of the created WireMock container.