### PR TITLE
(feature) SNSSQS Test Client: receive message attributes

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -8,9 +8,6 @@ def hooks() -> None:
 
 
 def format() -> None:
-    check_call(["ruff", "check", "--fix", "."])
-    check_call(["black", "."])
-    check_call(["isort", "."])
     check_call(
         [
             "autoflake",
@@ -22,6 +19,9 @@ def format() -> None:
             ".",
         ]
     )
+    check_call(["ruff", "check", "--fix", "."])
+    check_call(["black", "."])
+    check_call(["isort", "."])
 
 
 def lint() -> None:

--- a/docs_src/getting_started/customers/test_app001.py
+++ b/docs_src/getting_started/customers/test_app001.py
@@ -20,7 +20,7 @@ async def test_customer_created_event_emitted(
     # Assert
     events = await localstack_snssqs_tc.receive("customer--created", JsonBase, dict[str, str])
     assert len(events) == 1
-    assert events[0] == {
+    assert events[0].payload == {
         "customer_id": customer_id,
         "name": "John Doe",
     }

--- a/docs_src/getting_started/customers/test_app002.py
+++ b/docs_src/getting_started/customers/test_app002.py
@@ -23,7 +23,7 @@ async def test_customer_created_event_emitted(
 
     events = await localstack_snssqs_tc.receive("customer--created", JsonBase, dict[str, str])
     assert len(events) == 1
-    assert events[0] == {
+    assert events[0].payload == {
         "customer_id": customer_id,
         "name": "John Doe",
     }

--- a/docs_src/getting_started/customers/test_app003.py
+++ b/docs_src/getting_started/customers/test_app003.py
@@ -19,7 +19,7 @@ async def test_customer_created_event_emitted(
     # Assert
     async def _customer_created_event_emitted() -> dict[str, str]:
         [event] = await localstack_snssqs_tc.receive("customer--created", JsonBase, dict[str, str])
-        return event
+        return event.payload
 
     event = await probe_until(_customer_created_event_emitted, probe_interval=0.1, stop_after=3.0)
     assert event == {

--- a/docs_src/getting_started/customers/test_app005.py
+++ b/docs_src/getting_started/customers/test_app005.py
@@ -24,7 +24,7 @@ async def test_customer_not_found_for_newly_created_order(localstack_snssqs_tc: 
     # Assert
     async def _order_created_event_moved_to_dlq() -> dict[str, str]:
         [event] = await localstack_snssqs_tc.receive("customer--order-created--dlq", JsonBase, dict[str, str])
-        return event
+        return event.payload
 
     event = await probe_until(_order_created_event_moved_to_dlq, stop_after=10.0)
     assert event == {"order_id": order_id, "customer_id": customer_id}

--- a/src/tomodachi_testcontainers/clients/snssqs.py
+++ b/src/tomodachi_testcontainers/clients/snssqs.py
@@ -234,10 +234,10 @@ class SNSSQSTestClient:
         return parsed_message["data"]
 
     def _parse_received_message_attributes(self, received_message: SQSMessageTypeDef) -> Dict[str, Any]:
+        # When received from SNS, the message attributes are added to the "Body" key by tomodachi framework
+        with suppress(KeyError, json.JSONDecodeError):
+            return json.loads(received_message["Body"])["MessageAttributes"]
         # When received from SQS, the message attributes are in the "MessageAttributes" key
         if message_attributes := received_message.get("MessageAttributes"):
             return message_attributes
-        # When received from SNS, the message attributes are added by tomodachi to the "Body" key
-        with suppress(KeyError, json.JSONDecodeError):
-            return json.loads(received_message["Body"])["MessageAttributes"]
         return {}

--- a/tests/clients/test_snssqs.py
+++ b/tests/clients/test_snssqs.py
@@ -10,7 +10,7 @@ from types_aiobotocore_sqs import SQSClient
 
 from tests.clients.proto_build.message_pb2 import Person
 from tomodachi_testcontainers.clients import SNSSQSTestClient
-from tomodachi_testcontainers.clients.snssqs import QueueDoesNotExistError, TopicDoesNotExistError
+from tomodachi_testcontainers.clients.snssqs import QueueDoesNotExistError, SQSMessage, TopicDoesNotExistError
 
 pytestmark = pytest.mark.usefixtures("reset_moto_container_on_teardown")
 
@@ -43,7 +43,10 @@ async def test_publish_and_receive_messages(snssqs_test_client: SNSSQSTestClient
     await snssqs_test_client.publish("topic", {"message": "2"}, JsonBase)
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}, {"message": "2"}]
+    assert messages == [
+        SQSMessage({"message": "1"}),
+        SQSMessage({"message": "2"}),
+    ]
 
 
 @pytest.mark.asyncio()
@@ -68,7 +71,7 @@ async def test_publish_and_receive_with_message_attributes(snssqs_test_client: S
     )
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}]
+    assert messages == [SQSMessage({"message": "1"})]
 
 
 @pytest.mark.asyncio()
@@ -83,7 +86,7 @@ async def test_publish_and_receive_with_fifo(snssqs_test_client: SNSSQSTestClien
     )
 
     messages = await snssqs_test_client.receive("queue.fifo", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}]
+    assert messages == [SQSMessage({"message": "1"})]
 
 
 @pytest.mark.asyncio()
@@ -100,7 +103,7 @@ async def test_send_and_receive_message(snssqs_test_client: SNSSQSTestClient) ->
     await snssqs_test_client.send("queue", {"message": "2"}, JsonBase)
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}, {"message": "2"}]
+    assert messages == [SQSMessage({"message": "1"}), SQSMessage({"message": "2"})]
 
 
 @pytest.mark.asyncio()
@@ -115,7 +118,7 @@ async def test_send_and_receive_message_with_fifo(snssqs_test_client: SNSSQSTest
     )
 
     messages = await snssqs_test_client.receive("queue.fifo", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}]
+    assert messages == [SQSMessage({"message": "1"})]
 
 
 @pytest.mark.asyncio()
@@ -130,7 +133,7 @@ async def test_send_and_receive_messages_with_attributes(snssqs_test_client: SNS
     )
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [{"message": "1"}]
+    assert messages == [SQSMessage({"message": "1"})]
 
 
 @pytest.mark.asyncio()
@@ -153,10 +156,10 @@ async def test_receive_max_receive_messages(snssqs_test_client: SNSSQSTestClient
     await snssqs_test_client.publish("topic", {"message": "2"}, JsonBase)
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str], max_messages=1)
-    assert messages == [{"message": "1"}]
+    assert messages == [SQSMessage({"message": "1"})]
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str], max_messages=1)
-    assert messages == [{"message": "2"}]
+    assert messages == [SQSMessage({"message": "2"})]
 
 
 @pytest.mark.asyncio()
@@ -166,7 +169,7 @@ async def test_publish_and_receive_protobuf_message(snssqs_test_client: SNSSQSTe
 
     messages = await snssqs_test_client.receive("queue", ProtobufBase, Person)
 
-    assert messages == [Person(id="123456", name="John Doe")]
+    assert messages == [SQSMessage(Person(id="123456", name="John Doe"))]
 
 
 @pytest.mark.asyncio()

--- a/tests/clients/test_snssqs.py
+++ b/tests/clients/test_snssqs.py
@@ -71,7 +71,12 @@ async def test_publish_and_receive_with_message_attributes(snssqs_test_client: S
     )
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [SQSMessage({"message": "1"})]
+    assert messages == [
+        SQSMessage(
+            payload={"message": "1"},
+            message_attributes={"MyMessageAttribute": {"Type": "String", "Value": "will-be-included"}},
+        )
+    ]
 
 
 @pytest.mark.asyncio()
@@ -133,7 +138,12 @@ async def test_send_and_receive_messages_with_attributes(snssqs_test_client: SNS
     )
 
     messages = await snssqs_test_client.receive("queue", JsonBase, Dict[str, str])
-    assert messages == [SQSMessage({"message": "1"})]
+    assert messages == [
+        SQSMessage(
+            payload={"message": "1"},
+            message_attributes={"MyMessageAttribute": {"DataType": "String", "StringValue": "test-value"}},
+        )
+    ]
 
 
 @pytest.mark.asyncio()

--- a/tests/services/test_service_orders.py
+++ b/tests/services/test_service_orders.py
@@ -80,7 +80,7 @@ async def test_create_order(http_client: httpx.AsyncClient, moto_snssqs_tc: SNSS
 
     async def _order_created_event_emitted() -> Dict[str, Any]:
         [event] = await moto_snssqs_tc.receive("order--created", JsonBase, Dict[str, Any])
-        return event
+        return event.payload
 
     event = await probe_until(_order_created_event_emitted)
     assert_datetime_within_range(datetime.fromisoformat(event["created_at"]))

--- a/tests/services/test_service_s3.py
+++ b/tests/services/test_service_s3.py
@@ -68,7 +68,7 @@ async def test_upload_and_read_file(
 
     async def _file_uploaded_event_emitted() -> Dict[str, Any]:
         [event] = await localstack_snssqs_tc.receive("s3--file-uploaded", JsonBase, Dict[str, Any])
-        return event
+        return event.payload
 
     event = await probe_until(_file_uploaded_event_emitted)
     assert_datetime_within_range(datetime.fromisoformat(event["event_time"]))


### PR DESCRIPTION
`SNSSQSTestClient.receive` now returns the `SQSMessage` dataclass wrapper containing `payload` and `message_attributes` fields.

It's useful to test that the correct `message_attributes` are set on the published messages, so we need to return it once we receive a message.

This is a minor breaking change in the `SNSSQSTestClient.receive` function. Now, the message payload needs to be accessed with the `payload` property.