### PR TITLE
(feature) Disable logging with environment variable

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -6,11 +6,12 @@
 
 ## General configuration options
 
-| Environment Variable                      | Description                                                                |
-| :---------------------------------------- | :------------------------------------------------------------------------- |
-| `<CONTAINER-NAME>_TESTCONTAINER_IMAGE_ID` | Override Testcontainer's default Docker Image ID in pytest fixture.        |
-| `DOCKER_BUILDKIT`                         | Set `DOCKER_BUILDKIT=1` to use Docker BuildKit for building Docker images. |
-| `TESTCONTAINER_DOCKER_NETWORK`            | Launch Testcontainers in specified Docker network. Defaults to `bridge`.   |
+| Environment Variable                             | Description                                                                |
+| :----------------------------------------------- | :------------------------------------------------------------------------- |
+| `<CONTAINER-NAME>_TESTCONTAINER_IMAGE_ID`        | Override Testcontainer's default Docker Image ID in pytest fixture.        |
+| `DOCKER_BUILDKIT`                                | Set `DOCKER_BUILDKIT=1` to use Docker BuildKit for building Docker images. |
+| `TESTCONTAINER_DOCKER_NETWORK`                   | Launch Testcontainers in specified Docker network. Defaults to `bridge`.   |
+| `<CONTAINER-NAME>_TESTCONTAINER_DISABLE_LOGGING` | Disables log forwarding to stdout for given container.                     |
 
 ### Override Default Docker Image in pytest fixtures
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,8 @@ env = [
     "TESTCONTAINER_DOCKERFILE_PATH=examples/Dockerfile",
     "TESTCONTAINER_DOCKER_BUILD_CONTEXT=examples",
     "TESTCONTAINER_DOCKER_BUILD_TARGET=test",
+    # Moto Testcontainer configuration
+    "MOTO_TESTCONTAINER_DISABLE_LOGGING=1",
     # WireMock Testcontainer configuration
     "WIREMOCK_TESTCONTAINER_MAPPING_STUBS=tests/containers/test-wiremock-container/mappings",
     "WIREMOCK_TESTCONTAINER_MAPPING_FILES=tests/containers/test-wiremock-container/files",

--- a/src/tomodachi_testcontainers/containers/common/container.py
+++ b/src/tomodachi_testcontainers/containers/common/container.py
@@ -25,10 +25,14 @@ class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
     _name: str
     _logger: logging.Logger
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, disable_logging: bool = False, **kwargs: Any) -> None:
         self._set_container_network()
+
         super().__init__(*args, **kwargs, network=self.network)
+
         self._set_default_container_name()
+
+        self._disable_logging = disable_logging
 
     def __enter__(self) -> "DockerContainer":
         try:
@@ -43,7 +47,8 @@ class DockerContainer(testcontainers.core.container.DockerContainer, abc.ABC):
     def __exit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
-        self._forward_container_logs_to_logger()
+        if not self._disable_logging:
+            self._forward_container_logs_to_logger()
         self.stop()
 
     @abc.abstractmethod

--- a/src/tomodachi_testcontainers/containers/common/database.py
+++ b/src/tomodachi_testcontainers/containers/common/database.py
@@ -43,9 +43,10 @@ class DatabaseContainer(DockerContainer, abc.ABC):
         image: str,
         internal_port: int,
         edge_port: Optional[int] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(image, **kwargs)
+        super().__init__(image, disable_logging=disable_logging, **kwargs)
         self.internal_port = internal_port
         self.edge_port = edge_port or get_available_port()
         self.with_bind_ports(internal_port, self.edge_port)

--- a/src/tomodachi_testcontainers/containers/common/web.py
+++ b/src/tomodachi_testcontainers/containers/common/web.py
@@ -25,9 +25,10 @@ class WebContainer(DockerContainer, abc.ABC):
         internal_port: int,
         edge_port: Optional[int] = None,
         http_healthcheck_path: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(image, **kwargs)
+        super().__init__(image, disable_logging=disable_logging, **kwargs)
         self.internal_port = internal_port
         self.edge_port = edge_port or get_available_port()
         self.http_healthcheck_path = http_healthcheck_path

--- a/src/tomodachi_testcontainers/containers/dynamodb_admin.py
+++ b/src/tomodachi_testcontainers/containers/dynamodb_admin.py
@@ -19,6 +19,7 @@ class DynamoDBAdminContainer(WebContainer):
         internal_port: int = 8001,
         edge_port: Optional[int] = None,
         region_name: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -26,6 +27,7 @@ class DynamoDBAdminContainer(WebContainer):
             internal_port=internal_port,
             edge_port=edge_port,
             http_healthcheck_path="/",
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/containers/localstack.py
+++ b/src/tomodachi_testcontainers/containers/localstack.py
@@ -23,6 +23,7 @@ class LocalStackContainer(WebContainer):
         internal_port: int = 4566,
         edge_port: Optional[int] = None,
         region_name: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -30,6 +31,7 @@ class LocalStackContainer(WebContainer):
             internal_port=internal_port,
             edge_port=edge_port,
             http_healthcheck_path="/_localstack/health",
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/containers/minio.py
+++ b/src/tomodachi_testcontainers/containers/minio.py
@@ -23,6 +23,7 @@ class MinioContainer(WebContainer):
         console_internal_port: int = 9001,
         console_edge_port: Optional[int] = None,
         region_name: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -30,6 +31,7 @@ class MinioContainer(WebContainer):
             internal_port=s3_api_internal_port,
             edge_port=s3_api_edge_port,
             http_healthcheck_path="/minio/health/live",
+            disable_logging=disable_logging,
             **kwargs,
         )
         self.s3_api_internal_port = s3_api_internal_port

--- a/src/tomodachi_testcontainers/containers/moto.py
+++ b/src/tomodachi_testcontainers/containers/moto.py
@@ -23,6 +23,7 @@ class MotoContainer(WebContainer):
         internal_port: int = 5000,
         edge_port: Optional[int] = None,
         region_name: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -30,6 +31,7 @@ class MotoContainer(WebContainer):
             internal_port=internal_port,
             edge_port=edge_port,
             http_healthcheck_path="/moto-api/data.json",
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/containers/mysql.py
+++ b/src/tomodachi_testcontainers/containers/mysql.py
@@ -31,12 +31,14 @@ class MySQLContainer(DatabaseContainer):
         root_password: Optional[str] = None,
         password: Optional[str] = None,
         database: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             image,
             internal_port=internal_port,
             edge_port=edge_port,
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/containers/postgres.py
+++ b/src/tomodachi_testcontainers/containers/postgres.py
@@ -29,12 +29,14 @@ class PostgreSQLContainer(DatabaseContainer):
         username: Optional[str] = None,
         password: Optional[str] = None,
         database: Optional[str] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             image,
             internal_port=internal_port,
             edge_port=edge_port,
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/containers/sftp.py
+++ b/src/tomodachi_testcontainers/containers/sftp.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, NamedTuple, Optional
 
 import asyncssh
@@ -15,9 +16,10 @@ class SFTPContainer(DockerContainer):
         image: str = "atmoz/sftp:latest",
         internal_port: int = 22,
         edge_port: Optional[int] = None,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(image, **kwargs)
+        super().__init__(image, disable_logging=disable_logging, **kwargs)
         self.internal_port = internal_port
         self.edge_port = edge_port or get_available_port()
         self.with_bind_ports(self.internal_port, self.edge_port)

--- a/src/tomodachi_testcontainers/containers/sftp.py
+++ b/src/tomodachi_testcontainers/containers/sftp.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, NamedTuple, Optional
 
 import asyncssh

--- a/src/tomodachi_testcontainers/containers/tomodachi.py
+++ b/src/tomodachi_testcontainers/containers/tomodachi.py
@@ -26,6 +26,7 @@ class TomodachiContainer(WebContainer):
         http_healthcheck_path: Optional[str] = None,
         *,
         export_coverage: bool = False,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -33,6 +34,7 @@ class TomodachiContainer(WebContainer):
             internal_port=internal_port,
             edge_port=edge_port,
             http_healthcheck_path=http_healthcheck_path,
+            disable_logging=disable_logging,
             **kwargs,
         )
         self._export_coverage = export_coverage or bool(os.getenv("TOMODACHI_TESTCONTAINER_EXPORT_COVERAGE"))

--- a/src/tomodachi_testcontainers/containers/wiremock.py
+++ b/src/tomodachi_testcontainers/containers/wiremock.py
@@ -27,12 +27,14 @@ class WireMockContainer(WebContainer):
         mapping_files: Optional[Path] = None,
         *,
         verbose: bool = False,
+        disable_logging: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             image,
             internal_port=internal_port,
             edge_port=edge_port,
+            disable_logging=disable_logging,
             **kwargs,
         )
 

--- a/src/tomodachi_testcontainers/fixtures/localstack.py
+++ b/src/tomodachi_testcontainers/fixtures/localstack.py
@@ -19,7 +19,9 @@ from ..clients.snssqs import SNSSQSTestClient
 @pytest.fixture(scope="session")
 def localstack_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("LOCALSTACK_TESTCONTAINER_IMAGE_ID", "localstack/localstack:3")
-    with LocalStackContainer(image) as container:
+    disable_logging = bool(os.getenv("LOCALSTACK_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with LocalStackContainer(image, disable_logging=disable_logging) as container:
         yield container
 
 

--- a/src/tomodachi_testcontainers/fixtures/localstack.py
+++ b/src/tomodachi_testcontainers/fixtures/localstack.py
@@ -19,7 +19,7 @@ from ..clients.snssqs import SNSSQSTestClient
 @pytest.fixture(scope="session")
 def localstack_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("LOCALSTACK_TESTCONTAINER_IMAGE_ID", "localstack/localstack:3")
-    disable_logging = bool(os.getenv("LOCALSTACK_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("LOCALSTACK_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with LocalStackContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/minio.py
+++ b/src/tomodachi_testcontainers/fixtures/minio.py
@@ -12,7 +12,9 @@ from .. import DockerContainer, MinioContainer
 @pytest.fixture(scope="session")
 def minio_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MINIO_TESTCONTAINER_IMAGE_ID", "minio/minio:latest")
-    with MinioContainer(image) as container:
+    disable_logging = bool(os.getenv("MINIO_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with MinioContainer(image, disable_logging=disable_logging) as container:
         yield container
 
 

--- a/src/tomodachi_testcontainers/fixtures/minio.py
+++ b/src/tomodachi_testcontainers/fixtures/minio.py
@@ -12,7 +12,7 @@ from .. import DockerContainer, MinioContainer
 @pytest.fixture(scope="session")
 def minio_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MINIO_TESTCONTAINER_IMAGE_ID", "minio/minio:latest")
-    disable_logging = bool(os.getenv("MINIO_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("MINIO_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with MinioContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/moto.py
+++ b/src/tomodachi_testcontainers/fixtures/moto.py
@@ -19,7 +19,7 @@ from ..clients.snssqs import SNSSQSTestClient
 @pytest.fixture(scope="session")
 def moto_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MOTO_TESTCONTAINER_IMAGE_ID", "motoserver/moto:latest")
-    disable_logging = bool(os.getenv("MOTO_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("MOTO_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with MotoContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/moto.py
+++ b/src/tomodachi_testcontainers/fixtures/moto.py
@@ -19,7 +19,9 @@ from ..clients.snssqs import SNSSQSTestClient
 @pytest.fixture(scope="session")
 def moto_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MOTO_TESTCONTAINER_IMAGE_ID", "motoserver/moto:latest")
-    with MotoContainer(image) as container:
+    disable_logging = bool(os.getenv("MOTO_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with MotoContainer(image, disable_logging=disable_logging) as container:
         yield container
 
 

--- a/src/tomodachi_testcontainers/fixtures/mysql.py
+++ b/src/tomodachi_testcontainers/fixtures/mysql.py
@@ -9,5 +9,7 @@ from .. import DockerContainer, MySQLContainer
 @pytest.fixture(scope="session")
 def mysql_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MYSQL_TESTCONTAINER_IMAGE_ID", "mysql:8")
-    with MySQLContainer(image) as container:
+    disable_logging = bool(os.getenv("MYSQL_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with MySQLContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/mysql.py
+++ b/src/tomodachi_testcontainers/fixtures/mysql.py
@@ -9,7 +9,7 @@ from .. import DockerContainer, MySQLContainer
 @pytest.fixture(scope="session")
 def mysql_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("MYSQL_TESTCONTAINER_IMAGE_ID", "mysql:8")
-    disable_logging = bool(os.getenv("MYSQL_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("MYSQL_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with MySQLContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/postgres.py
+++ b/src/tomodachi_testcontainers/fixtures/postgres.py
@@ -11,7 +11,7 @@ from .. import PostgreSQLContainer
 @pytest.fixture(scope="session")
 def postgres_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("POSTGRES_TESTCONTAINER_IMAGE_ID", "postgres:16")
-    disable_logging = bool(os.getenv("POSTGRES_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("POSTGRES_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with PostgreSQLContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/postgres.py
+++ b/src/tomodachi_testcontainers/fixtures/postgres.py
@@ -11,5 +11,7 @@ from .. import PostgreSQLContainer
 @pytest.fixture(scope="session")
 def postgres_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("POSTGRES_TESTCONTAINER_IMAGE_ID", "postgres:16")
-    with PostgreSQLContainer(image) as container:
+    disable_logging = bool(os.getenv("POSTGRES_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with PostgreSQLContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/sftp.py
+++ b/src/tomodachi_testcontainers/fixtures/sftp.py
@@ -13,7 +13,9 @@ from .. import SFTPContainer
 @pytest.fixture(scope="session")
 def sftp_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("SFTP_TESTCONTAINER_IMAGE_ID", "atmoz/sftp:latest")
-    with SFTPContainer(image) as container:
+    disable_logging = bool(os.getenv("SFTP_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with SFTPContainer(image, disable_logging=disable_logging) as container:
         yield container
 
 

--- a/src/tomodachi_testcontainers/fixtures/sftp.py
+++ b/src/tomodachi_testcontainers/fixtures/sftp.py
@@ -13,7 +13,7 @@ from .. import SFTPContainer
 @pytest.fixture(scope="session")
 def sftp_container() -> Generator[DockerContainer, None, None]:
     image = os.getenv("SFTP_TESTCONTAINER_IMAGE_ID", "atmoz/sftp:latest")
-    disable_logging = bool(os.getenv("SFTP_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("SFTP_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with SFTPContainer(image, disable_logging=disable_logging) as container:
         yield container

--- a/src/tomodachi_testcontainers/fixtures/wiremock.py
+++ b/src/tomodachi_testcontainers/fixtures/wiremock.py
@@ -14,7 +14,9 @@ except ImportError:
 @pytest.fixture(scope="session")
 def wiremock_container() -> Generator[WireMockContainer, None, None]:
     image = os.getenv("WIREMOCK_TESTCONTAINER_IMAGE_ID", "wiremock/wiremock:latest")
-    with WireMockContainer(image) as container:
+    disable_logging = bool(os.getenv("WIREMOCK_TESTCONTAINER_DISABLE_LOGGING", False))
+
+    with WireMockContainer(image, disable_logging=disable_logging) as container:
         container = cast(WireMockContainer, container)
         if WireMockConfig is not None:
             WireMockConfig.base_url = f"{container.get_external_url()}/__admin/"

--- a/src/tomodachi_testcontainers/fixtures/wiremock.py
+++ b/src/tomodachi_testcontainers/fixtures/wiremock.py
@@ -14,7 +14,7 @@ except ImportError:
 @pytest.fixture(scope="session")
 def wiremock_container() -> Generator[WireMockContainer, None, None]:
     image = os.getenv("WIREMOCK_TESTCONTAINER_IMAGE_ID", "wiremock/wiremock:latest")
-    disable_logging = bool(os.getenv("WIREMOCK_TESTCONTAINER_DISABLE_LOGGING", False))
+    disable_logging = bool(os.getenv("WIREMOCK_TESTCONTAINER_DISABLE_LOGGING")) or False
 
     with WireMockContainer(image, disable_logging=disable_logging) as container:
         container = cast(WireMockContainer, container)


### PR DESCRIPTION
Logs from some containers are not often useful, for example, Moto container logs are simple HTTP access logs that are not immediately helpful for debugging.

To reduce clutter in standard output, add `<CONTAINER-NAME>_TESTCONTAINER_DISABLE_LOGGING` envvars that allow to selectively disable log forwarding to std out, e.g., `MOTO_TESTCONTAINER_DISABLE_LOGGING=1`.


Example:

Without `MOTO_TESTCONTAINER_DISABLE_LOGGING=1`:
![image](https://github.com/filipsnastins/tomodachi-testcontainers/assets/47500046/2d4da369-ca9e-4453-90b2-cd9b0c20cd93)


With `MOTO_TESTCONTAINER_DISABLE_LOGGING=1`:
![image](https://github.com/filipsnastins/tomodachi-testcontainers/assets/47500046/08a967fb-1213-451f-ac08-0f8c96c08030)